### PR TITLE
Potential fix for code scanning alert no. 2: Redundant null check due to previous dereference

### DIFF
--- a/src/SIUnit.c
+++ b/src/SIUnit.c
@@ -1504,14 +1504,15 @@ static SIUnitRef SIUnitByRaisingToPowerInternal(SIUnitRef input,
     }
     if (!dimensionality) return NULL;
     // Calculate the new scale factor
+    if (!unit_multiplier) {
+        return NULL;
+    }
     double scale = pow(*unit_multiplier, power);
     *unit_multiplier = scale;
     // First approach: Look for existing units with matching dimensionality
     SIUnitRef best_match = SIUnitFindBestMatchingUnit(dimensionality, scale);
     if (best_match) {
-        if (unit_multiplier) {
-            *unit_multiplier *= scale / best_match->scale_to_coherent_si;
-        }
+        *unit_multiplier *= scale / best_match->scale_to_coherent_si;
         return best_match;
     }
     // Second approach: Create new symbol by wrapping input symbol with "( )^power"


### PR DESCRIPTION
Potential fix for [https://github.com/pjgrandinetti/SITypes/security/code-scanning/2](https://github.com/pjgrandinetti/SITypes/security/code-scanning/2)

To fix the problem, the redundant null check at line 1512 should be addressed. The best way is to ensure `unit_multiplier` is checked for null before any dereferencing, specifically before line 1507, where `*unit_multiplier` is first accessed. 

- Move the null check for `unit_multiplier` above line 1507 (before any dereference), and if it is null, either return early (e.g., `return NULL;`) or handle the error according to the function's pattern.
- Remove the check at line 1512, since after pointer dereference, checking for null is pointless.
- No imports or additional method definitions are needed.
- Only code within `SIUnitByRaisingToPowerInternal` needs to be changed; add the new check before line 1507 and remove/adjust line 1512.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
