### PR TITLE
Potential fix for code scanning alert no. 3: Redundant null check due to previous dereference

### DIFF
--- a/src/SIUnit.c
+++ b/src/SIUnit.c
@@ -1723,9 +1723,7 @@ SIUnitRef SIUnitByTakingNthRoot(SIUnitRef theUnit,
     // First approach: Look for existing units with matching dimensionality
     SIUnitRef best_match = SIUnitFindBestMatchingUnit(dimensionality, scale);
     if (best_match) {
-        if (unit_multiplier) {
-            *unit_multiplier *= scale / best_match->scale_to_coherent_si;
-        }
+        *unit_multiplier *= scale / best_match->scale_to_coherent_si;
         return best_match;
     }
     // Second approach: Create new symbol by wrapping input symbol with "( )^(1/root)"


### PR DESCRIPTION
Potential fix for [https://github.com/pjgrandinetti/SITypes/security/code-scanning/3](https://github.com/pjgrandinetti/SITypes/security/code-scanning/3)

To resolve the flagged error, remove the redundant null check for `unit_multiplier` at line 1726. The assignment to `*unit_multiplier` on line 1722 would already invoke undefined behavior if `unit_multiplier` is NULL, so the code block on line 1726 does not provide any actual safety. The fix involves deleting the `if (unit_multiplier) { ... }` conditional and unconditionally updating `*unit_multiplier`. Change:

```c
if (unit_multiplier) {
    *unit_multiplier *= scale / best_match->scale_to_coherent_si;
}
```

to

```c
*unit_multiplier *= scale / best_match->scale_to_coherent_si;
```

This should be done in file `src/SIUnit.c` within the function `SIUnitByTakingNthRoot`. No additional methods, imports, or definitions are needed, as the logic is simple and only requires a code edit to an existing block. Be careful to preserve the surrounding code and indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
